### PR TITLE
Add fix to parse inline comments

### DIFF
--- a/citations.py
+++ b/citations.py
@@ -28,10 +28,11 @@ def get_citation_tags_from_config(filepath):
         # go through each line
         for line in file:
             # find any lines that aren't blank/comments
-            if not line.strip().startswith("#") and len(line.strip()) > 0:
+            # Need to parse inline comments too. '#' is guaranteed to introduce a comment
+            setting = line.strip().split("#")[0].strip()
+            if len(setting) > 0:
                 # take just the initial setting name, remove anything after an equals sign
-                setting = line.strip().split(" ")[0]
-                setting = setting.split("=")[0] if "=" in setting else setting
+                setting = setting.split("=")[0].strip() if "=" in setting else setting
                 settings_on.add(setting)
 
     # track which tags are relevant based on the settings    


### PR DESCRIPTION
Comments in the config file can be inline, need to be able to remove them in the case where there's no equal sign. There might be a simpler way of doing it though. You can modify the included Template_Config.sh as a test example, though you'd need to uncomment some of the lines.